### PR TITLE
Fix stringified nulls in UID mapping

### DIFF
--- a/src/logic_network_generator.py
+++ b/src/logic_network_generator.py
@@ -236,7 +236,23 @@ def get_negative_regulators_for_reaction(
 
 def _get_non_null_values(df: pd.DataFrame, column: str) -> List[Any]:
     """Extract non-null values from a DataFrame column."""
-    return [value for value in df[column].tolist() if pd.notna(value)]
+    return [value for value in df[column].tolist() if not _is_missing_value(value)]
+
+
+def _is_missing_value(value: Any) -> bool:
+    """Return True for real nulls and stringified nulls from cached CSV reloads."""
+    if pd.isna(value):
+        return True
+    if isinstance(value, str) and value.strip() in {"None", "nan", "NaN", "<NA>"}:
+        return True
+    return False
+
+
+def _is_missing_reference_value(value: Any) -> bool:
+    """Return True when a UID/reference field should not become a graph ID."""
+    if _is_missing_value(value):
+        return True
+    return isinstance(value, str) and value.strip() == ""
 
 
 def _get_hash_for_reaction(reaction_id_map: pd.DataFrame, uid: str, hash_type: str) -> str:
@@ -254,15 +270,21 @@ def _build_uid_index(decomposed_uid_mapping: pd.DataFrame) -> Dict[str, tuple]:
     """
     index: Dict[str, tuple] = {}
     for uid_val, group in decomposed_uid_mapping.groupby("uid"):
-        nested_uids = _get_non_null_values(group, "input_or_output_uid")
-        terminal_ids = _get_non_null_values(group, "input_or_output_reactome_id")
+        nested_uids = [
+            value for value in group["input_or_output_uid"].tolist()
+            if not _is_missing_reference_value(value)
+        ]
+        terminal_ids = [
+            value for value in group["input_or_output_reactome_id"].tolist()
+            if not _is_missing_reference_value(value)
+        ]
         stoich_map: Dict[str, int] = {}
         for _, row in group.iterrows():
             stoich_raw = row.get("stoichiometry")
             stoich = 1 if stoich_raw is None or pd.isna(stoich_raw) else int(stoich_raw)
-            if pd.notna(row.get("input_or_output_uid")):
+            if not _is_missing_reference_value(row.get("input_or_output_uid")):
                 stoich_map[row["input_or_output_uid"]] = stoich
-            if pd.notna(row.get("input_or_output_reactome_id")):
+            if not _is_missing_reference_value(row.get("input_or_output_reactome_id")):
                 stoich_map[row["input_or_output_reactome_id"]] = stoich
         index[str(uid_val)] = (nested_uids, terminal_ids, stoich_map)
     return index

--- a/tests/test_logic_network_generator.py
+++ b/tests/test_logic_network_generator.py
@@ -15,11 +15,13 @@ sys.path.insert(0, str(project_root))
 with patch('py2neo.Graph'):
     from src.logic_network_generator import (
         _assign_uuids,
+        _build_uid_index,
         _build_entity_producer_count,
         _canonicalize_registry,
         _emit_boundary_decomposition_edges,
         _register_entity_uuid,
         _get_or_create_entity_uuid,
+        _resolve_to_terminal_reactome_ids,
         _resolve_vr_entities,
     )
 
@@ -144,6 +146,52 @@ class TestEntityProducerCount:
         count = _build_entity_producer_count(vr_entities)
         assert count["X"] == 1
         assert count["Y"] == 1
+
+
+class TestUidIndex:
+    """Tests for cached decomposition UID resolution."""
+
+    def test_stringified_nulls_are_not_treated_as_entities(self):
+        """Cached CSV reloads can contain literal 'None' strings; skip them."""
+        decomposed = pd.DataFrame(
+            [
+                {
+                    "uid": "hash-1",
+                    "input_or_output_uid": "None",
+                    "input_or_output_reactome_id": "R-HSA-1",
+                    "stoichiometry": 2,
+                },
+                {
+                    "uid": "hash-1",
+                    "input_or_output_uid": "",
+                    "input_or_output_reactome_id": "nan",
+                    "stoichiometry": 1,
+                },
+                {
+                    "uid": "hash-1",
+                    "input_or_output_uid": "hash-2",
+                    "input_or_output_reactome_id": "<NA>",
+                    "stoichiometry": 3,
+                },
+                {
+                    "uid": "hash-2",
+                    "input_or_output_uid": "NaN",
+                    "input_or_output_reactome_id": "R-HSA-2",
+                    "stoichiometry": 4,
+                },
+            ]
+        )
+
+        uid_index = _build_uid_index(decomposed)
+
+        assert uid_index["hash-1"][0] == ["hash-2"]
+        assert uid_index["hash-1"][1] == ["R-HSA-1"]
+        assert "None" not in uid_index["hash-1"][2]
+        assert "nan" not in uid_index["hash-1"][2]
+
+        resolved = _resolve_to_terminal_reactome_ids(uid_index, "hash-1")
+
+        assert resolved == {"R-HSA-1": 2, "R-HSA-2": 12}
 
 
 class TestInterReactionConnectivity:


### PR DESCRIPTION
## Description

Fixes a UID mapping bug where cached null values reloaded as strings (for example `"None"`, `"nan"`, `"<NA>"`) were treated as real Reactome/entity IDs. This caused fake string-null IDs to propagate into UID indexing and downstream stable-ID exports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, performance, etc.)

## Related Issue

N/A

## Changes Made

- Added `_is_missing_value()` to consistently detect real nulls and stringified null values.
- Updated UID mapping/index logic so stringified nulls are not treated as valid terminal entity IDs.
- Added regression coverage for stringified-null UID mapping behavior.

## Testing

### Unit Tests

- [ ] All existing unit tests pass locally (`poetry run pytest tests/ -v -m "not database"`)
- [x] Added new unit tests for changes (if applicable)

Targeted test run:

`python -m pytest tests/test_logic_network_generator.py -q`

Result:

`21 passed in 1.66s`

### Manual Testing

Describe any manual testing performed:

- Tested with pathway ID(s): N/A for this PR; covered by unit regression.
- Verified output files: N/A.

## Code Quality

- [ ] Code follows project style guidelines (ruff)
- [ ] Ran `poetry run ruff check src/` with no errors
- [ ] Ran `poetry run ruff format src/`
- [ ] Type hints added/updated where applicable
- [ ] Ran `poetry run mypy --ignore-missing-imports src/` (optional)

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Added/updated docstrings
- [ ] Updated relevant documentation in `docs/`

## Checklist

- [x] Self-review completed
- [x] Code is well-commented, particularly in complex areas
- [x] No debugging code left in (print statements, breakpoints, etc.)
- [x] No credentials or sensitive information in code
- [x] Git commit messages are clear and descriptive

## Screenshots (if applicable)

N/A