### PR TITLE
Fix Reactome release version sentinel

### DIFF
--- a/tests/test_reactome_version.py
+++ b/tests/test_reactome_version.py
@@ -29,7 +29,8 @@ def test_reactome_version_loaded(capsys):
     rows = graph.run(
         """
         MATCH (info:DBInfo)
-        RETURN info.name AS name, info.version AS version
+        RETURN info.name AS name,
+               toInteger(coalesce(info.releaseNumber, info.version)) AS version
         LIMIT 1
         """
     ).data()


### PR DESCRIPTION
## Description

Fix the Reactome version sentinel for current official graph images. Release 96 stores the release under `DBInfo.releaseNumber`, while the test only queried the older `DBInfo.version` property.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, performance, etc.)

## Changes Made

- Read `DBInfo.releaseNumber` with `DBInfo.version` as a compatibility fallback.
- Convert the selected value to an integer in Cypher so the existing sanity check remains stable.

## Testing

### Unit Tests
- [x] Added coverage through the existing database sentinel

### Integration Tests
- [x] Ran `tests/test_reactome_version.py` against the official Reactome Release 96 Neo4j image

### Manual Testing
- Verified output: `[reactome-version] tests ran against reactome v96`

## Checklist

- [x] Self-review completed
- [x] No debugging code left in
- [x] No credentials or sensitive information in code
- [x] Git commit message is clear and descriptive

## Additional Notes

This is intentionally a small compatibility fix and does not change generated networks.