### PR TITLE
Bump Reactome graph DB to Release97

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   neo4j:
     # Bump this tag when a new Reactome release lands; the version sentinel
     # test in tests/test_reactome_version.py records what we ran against.
-    image: public.ecr.aws/reactome/graphdb:Release96
+    image: public.ecr.aws/reactome/graphdb:Release97
     container_name: reactome-neo4j
     ports:
       - "7474:7474"  # HTTP


### PR DESCRIPTION
Pin the graph DB image to Release 97 to match the diagram files (`~/reactome-diagrams/97`) and current Reactome.

## Why
The diagrams are Release 97 but the DB was pinned to Release 96. That skew made ~85 diagram `following` (preceding-event) pairs look "missing from Neo4j" — but 95% of them reference R97 reactions that simply don't exist in the R96 DB (e.g. `R-HSA-9980233` "PIP3 activates mTORC2"). It was a version gap, not the diagram holding connectivity the database lacks.

**Verified:** with the DB on R97, diagram `following` pairs == Neo4j `precedingEvent` exactly — **0 diagram-only pairs** (was 85 at R96). So no diagram-parsing is needed to recover preceding events; matching the release closes the gap.

## Mechanics
The DB is baked into the image at `/var/lib/neo4j/data`; the `neo4j_data:/data` volume is vestigial (mounted at the wrong path, 12K empty). So the tag bump + `docker compose up -d --force-recreate neo4j` serves R97 with no volume surgery. Version sentinel test (`test_reactome_version.py`) now reports v97 and passes; full non-Neo4j suite: 923 passed.

## Note
Previously-generated catalogs (`output/`, MP-BioPath refs) are R96-based — regenerate against R97 if the networks should track the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)